### PR TITLE
CircleCIでの自動テスト設定を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: ryutah/gcp-python
+    working_directory: /lgbot-judge
+    steps:
+      - checkout
+      - run:
+          name: Download application dependencies
+          command: "pip install -r /lgbot-judge/requirements.txt"
+      - run:
+          name: Run unit test
+          command: "/lgbot-judge/script/test.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-FROM python:alpine3.7
-
-ARG BUILD_DEPS="linux-headers alpine-sdk"
-
-RUN apk add --no-cache ${BUILD_DEPS} \
- && rm -rf /tmp/*
+FROM ryutah/gcp-python
 
 COPY ./requirements.txt /tmp
 


### PR DESCRIPTION
close #5 

とりあえず、CircleCIでコードPush時に自動テスト走るように設定。
あと、ビルド用Dockerとアプリ実行用Dockerイメージで共通のミドルウェアが必要になったんで、別途コンテナイメージ作って、ベースイメージでそれ使うようにした。

[ベースイメージ](https://hub.docker.com/r/ryutah/gcp-python/)