### PR TITLE
自動デプロイをCIの設定に追加

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,26 @@
+FROM docker:18.02.0-ce-git
+ENV CLOUD_SDK_VERSION 191.0.0
+
+ENV PATH /google-cloud-sdk/bin:$PATH
+
+RUN apk --no-cache add \
+      curl \
+      python2 \
+      py-crcmod \
+      bash \
+      libc6-compat \
+      openssh-client \
+      git
+
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+ && tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+ && rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
+ && ln -s /lib /lib64 \
+ && gcloud config set core/disable_usage_reporting true \
+ && gcloud config set component_manager/disable_update_check true \
+ && gcloud config set metrics/environment github_docker_image \
+ && gcloud --version
+
+RUN cd /usr/local/bin \
+ && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.3/bin/linux/amd64/kubectl \
+ && chmod +x /usr/local/bin/kubectl

--- a/.circleci/build_image.sh
+++ b/.circleci/build_image.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -eux
+
+function build_push_docker_image() {
+  local docker_tag=gcr.io/${PROJECT_ID}/${IMAGE_NAME}
+  local tag=$(echo ${CIRCLE_SHA1} | cut -c 1-7)
+  gcloud docker -- build -t ${docker_tag} -t ${docker_tag}:${tag} .
+}
+
+cd $(dirname $0)/..
+build_push_docker_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,24 @@
 version: 2
+
+references:
+  build_docker: &build_docker
+    docker:
+      - image: gcr.io/dev-ryutah/lgbot-judge-builder:20180302
+        auth:
+          username: _json_key
+          password: $GOOGLE_AUTH_KEY
+  auth_steps:
+    - output_auth_key: &output_auth_key
+        name: output google auth key
+        command: "echo ${GOOGLE_AUTH_KEY} > /key.json"
+    - activate_account: &activate_account
+        name: activate google auth
+        command: |
+          echo ${GOOGLE_AUTH_KEY} > /key.json
+          gcloud auth activate-service-account --key-file /key.json
+
 jobs:
-  build:
+  test:
     docker:
       - image: ryutah/gcp-python
     working_directory: /lgbot-judge
@@ -12,3 +30,52 @@ jobs:
       - run:
           name: Run unit test
           command: "/lgbot-judge/script/test.sh"
+
+  build-docker:
+    <<: *build_docker
+    working_directory: /lgbot-judge
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          <<: *output_auth_key
+      - run:
+          <<: *activate_account
+      - run:
+          name: build docker image
+          command: "/lgbot-judge/.circleci/build_image.sh"
+      - run:
+          name: push docker image
+          command: |
+            docker_tag=gcr.io/${PROJECT_ID}/${IMAGE_NAME}
+            gcloud docker -- push ${docker_tag}
+
+  deploy:
+    <<: *build_docker
+    working_directory: /lgbot-judge
+    steps:
+      - checkout
+      - run:
+          <<: *output_auth_key
+      - run:
+          <<: *activate_account
+      - run:
+          name: deploy kubernetes deployments
+          command: "/lgbot-judge/.circleci/deploy.sh"
+
+workflows:
+  version: 2
+  test_to_deploy:
+    jobs:
+      - test
+      - build-docker:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
+            tags:
+              ignore: /.*/
+      - deploy:
+          requires:
+            - build-docker

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -euv
+
+cd $(dirname $0)/../
+
+gcloud config set project ${PROJECT_ID}
+gcloud container clusters get-credentials lgbot-judge --zone us-central1-a
+
+tag=$(echo ${CIRCLE_SHA1} | cut -c 1-7)
+
+sed -i -e "s/\${PROJECT_ID}/${PROJECT_ID}/g" k8s/deployment.yaml
+sed -i -e "s/\${DOCKER_IMAGE}/gcr\.io\/${PROJECT_ID}\/${IMAGE_NAME}:${tag}/g" k8s/deployment.yaml
+sed -i -e "s/\${SUBSCRIPTION_NAME}/${SUBSCRIPTION}/g" k8s/deployment.yaml
+sed -i -e "s/\${TOPIC_NAME}/${TOPIC}/g" k8s/deployment.yaml
+
+kubectl apply -f k8s/

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: judge-deployment
@@ -7,8 +7,6 @@ metadata:
 
 spec:
   replicas: 1
-  strategy:
-    type: RollingUpdate
   selector:
     matchLabels:
       app: judge-template
@@ -19,7 +17,11 @@ spec:
     spec:
       containers:
       - name: judge
-        image: gcr.io/$PROJECT_ID/judge:$BUILD_ID
+        image: ${DOCKER_IMAGE}
         env:
           - name: PROJECT_ID
-            value: $PROJECT_ID
+            value: ${PROJECT_ID}
+          - name: SUBSCRIPTION_NAME
+            value: ${SUBSCRIPTION_NAME}
+          - name: TOPIC_NAME
+            value: ${TOPIC_NAME}

--- a/script/create_cluster.sh
+++ b/script/create_cluster.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -eux
+
+gcloud beta container --project ${PROJECT_ID} clusters create "lgbot-judge" \
+  --zone "us-central1-a" \
+  --no-enable-basic-auth \
+  --cluster-version "1.9.2-gke.1" \
+  --machine-type "g1-small" \
+  --image-type "COS" \
+  --disk-size "10" \
+  --scopes "https://www.googleapis.com/auth/bigquery","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/pubsub","https://www.googleapis.com/auth/trace.append" \
+  --preemptible \
+  --num-nodes "1" \
+  --network "default" \
+  --enable-cloud-logging \
+  --enable-cloud-monitoring \
+  --subnetwork "default"

--- a/script/publish_message.sh
+++ b/script/publish_message.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-docker exec -it judge_app_1 python /judge/app/run.py publish "$1"

--- a/script/replace_deployment_yaml.sh
+++ b/script/replace_deployment_yaml.sh
@@ -1,5 +1,0 @@
-#!/bin/sh -eux
-
-cd $(dirname $0)
-sed -i -e"s/\$PROJECT_ID/$PROJECT_ID/g" k8s/deployment.yaml
-sed -i -e"s/\$BUILD_ID/$BUILD_ID/g" k8s/deployment.yaml

--- a/script/run_local.sh
+++ b/script/run_local.sh
@@ -1,9 +1,0 @@
-#!/bin/sh -eux
-
-# Exec in local docker container
-# Create Emulators Topic and Subscription, and listhen message.
-
-echo "{}" > /tmp/key.json
-
-sleep 5
-python ../app/run.py prepare


### PR DESCRIPTION
close #15 

* CircleCIでの自動デプロイの設定
* 不要になったスクリプトの整理

この設定で、 `master` ブランチへのPushをトリガーとしてデプロイが行われるようにしたんで、デフォルトブランチを `develop` に変更してます。